### PR TITLE
Quote original command arguments.

### DIFF
--- a/cronlock
+++ b/cronlock
@@ -223,7 +223,7 @@ if [ "${CRONLOCK_TIMEOUT}" -le 0 ]; then
 fi
 
 # Execute original command
-${timeoutcmd} ${@}
+${timeoutcmd} "${@}"
 exitcode=${?}
 
 if [ "${CRONLOCK_TIMEOUT}" -gt 0 ]; then


### PR DESCRIPTION
This allows for commands like `php foo.php "argument 1" "argument 2"` to be handled correctly.

