### PR TITLE
Add Alpine Support

### DIFF
--- a/cronlock
+++ b/cronlock
@@ -189,9 +189,8 @@ fi
 if [ "${CRONLOCK_TIMEOUT}" -gt 0 ]; then
   # ubuntu: aptitude install timeout
   timeout="$(which timeout)"
-  [[ $(readlink $timeout) == "/bin/busybox" ]] && /bin/busybox | head -n 1 | egrep -q 'v1\.2[0-9]\.[0-9]+'
   # if we are on alpine version between 2.6 and 3.9, use different timeout command structure
-  if [ $? -eq 0 ]; then
+  if [[ $(readlink $timeout) == "/bin/busybox" ]] && /bin/busybox | head -n 1 | egrep -q 'v1\.2[0-9]\.[0-9]+'; then
     timeoutcmd="timeout -t ${CRONLOCK_TIMEOUT} -s 9"
   else
     timeoutcmd="timeout -s 9 ${CRONLOCK_TIMEOUT}"

--- a/cronlock
+++ b/cronlock
@@ -189,7 +189,14 @@ fi
 if [ "${CRONLOCK_TIMEOUT}" -gt 0 ]; then
   # ubuntu: aptitude install timeout
   timeout="$(which timeout)"
-  timeoutcmd="timeout -s 9 ${CRONLOCK_TIMEOUT}"
+  [[ $(readlink $timeout) == "/bin/busybox" ]] && /bin/busybox | head -n 1 | egrep -q 'v1\.2[0-9]\.[0-9]+'
+  # if we are on alpine version between 2.6 and 3.9, use different timeout command structure
+  if [ $? -eq 0 ]; then
+    timeoutcmd="timeout -t ${CRONLOCK_TIMEOUT} -s 9"
+  else
+    timeoutcmd="timeout -s 9 ${CRONLOCK_TIMEOUT}"
+  fi
+
   if [ ! -x "${timeout}" ]; then
     # osx: brew install timelimit
     timeout="$(which timelimit)"


### PR DESCRIPTION
This PR adds support for Alpine Linux distribution that uses BusyBox's `timeout` command.

There is an additional `-t` parameter needed for all BusyBox's versions from 1.21.x (Alpine 2.6) till 1.29.x (Alpine 3.9). From 1.30.x (Alpine 3.10) the additional flag is gone...

More info: #14 